### PR TITLE
Optimized library to only draw changed pixels

### DIFF
--- a/adafruit_pixel_framebuf.py
+++ b/adafruit_pixel_framebuf.py
@@ -85,6 +85,7 @@ class PixelFramebuffer(adafruit_framebuf.FrameBuffer):
         )
 
         self._buffer = bytearray(width * height * 3)
+        self._double_buffer = bytearray(width * height * 3)
         super().__init__(
             self._buffer, width, height, buf_format=adafruit_framebuf.RGB888
         )
@@ -99,5 +100,12 @@ class PixelFramebuffer(adafruit_framebuf.FrameBuffer):
         for _y in range(self._height):
             for _x in range(self._width):
                 index = (_y * self.stride + _x) * 3
-                self._grid[(_x, _y)] = tuple(self._buffer[index : index + 3])
+                if (
+                    self._buffer[index : index + 3]
+                    != self._double_buffer[index : index + 3]
+                ):
+                    self._grid[(_x, _y)] = tuple(self._buffer[index : index + 3])
+                    self._double_buffer[index : index + 3] = self._buffer[
+                        index : index + 3
+                    ]
         self._grid.show()


### PR DESCRIPTION
I optimized the library to only update pixels that have changed. The result is that scrolling text is about twice as fast with this change. The only downside is it uses more memory in order to keep track of changes.